### PR TITLE
Feature/leader election

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +319,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "ryu"
@@ -400,6 +426,7 @@ dependencies = [
  "assert_cmd",
  "ctor",
  "redis",
+ "regex",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,13 @@
 license = "MIT"
 version = "0.0.1"
 name = "tinyredis"
-authors = ["Namra Patel"]
+authors = ["Namra Patel", "Jake Bunting"]
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.59"
 tokio = { version = "1.23.0", features = ["full"] }
+regex = "1"
 
 [dev-dependencies]
 ctor = "0.1.26"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod server;
 mod resp;
 mod cache;
-mod node;
+mod simpleElection;
 
 use anyhow::{Result};
 use server::Server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod server;
 mod resp;
 mod cache;
+mod node;
 
 use anyhow::{Result};
 use server::Server;

--- a/src/simpleElection.rs
+++ b/src/simpleElection.rs
@@ -1,0 +1,173 @@
+use crate::{resp::RESPMessage};
+use std::{collections::HashMap, process};
+use std::net::{TcpStream};
+use std::io::{Read, Write};
+use std::time::Duration;
+use std:: thread;
+use std::process::{Command, Stdio};
+use regex::Regex;
+
+// continuously ping the leader and start an election when timout occures
+pub fn ping_leader(ports: &[String]) {
+    loop {
+        let response = send_ping_message_to_leader();
+        let trimmed_response = response.trim_start_matches('+').trim();
+
+        if trimmed_response != "PONG" {
+            start_election(ports);
+            thread::sleep(Duration::from_secs(10));
+        } else {
+            println!("PONG from leader recieved");
+            thread::sleep(Duration::from_secs(10));
+        } 
+    }
+}
+
+// a simple election algorithm that elects the server with the highest process id
+fn start_election(ports: &[String]) {
+    let mut server_ids = HashMap::new();
+    // loop over the secondary server ports and get their server Ids
+    for port in ports {
+        // send get server id message a save response
+        let response = send_get_server_id_message(port.to_string());
+        // match response with process ID regex (if not a match the server at that port is not alive)
+        let reg = Regex::new(r"^\+\d+\r\n").unwrap();
+
+        match reg.is_match(&response) {
+            true => {
+                // trim response and convert to i32
+                let trimmed_response = response.trim_start_matches('+').trim();
+                let server_id = trimmed_response.parse::<i32>().unwrap();
+
+                // store server id as key in hash map
+                server_ids.insert(server_id, port.to_string());
+            },
+            false => {
+                println!("No server alive at port {}", port);
+            }
+        }
+    }
+    
+    // loop over the server IDs and find the server with the largest I
+    let mut max_id = std::process::id() as i32;
+    for (&server_id, port) in server_ids.iter() {
+        if server_id > max_id {
+            max_id = server_id;
+        }
+    }
+    // get the port of the server with max_id
+    // if its not found in the map that means this server has the highest id
+    match server_ids.get(&max_id) {
+        Some(value) => {
+            println!("server at port {} has the max id of {}", value, max_id);
+            send_set_leader_message(value.to_string());
+        },
+        None => {
+            println!("Initiating server has highest id of {}. Becoming leader...", max_id);
+            let mut child = Command::new(std::env::args().next().unwrap())
+                .arg("6379")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start new instance of the program");
+            process::exit(0);
+        },
+    }
+}
+
+// request server id from a server
+fn send_get_server_id_message(port: String) -> String {
+    let addr = "localhost:".to_string() + "" + &port;
+    let mut stream = match TcpStream::connect(addr) {
+        Ok(stream) => stream,
+        Err(e) => {
+            return "NOTALIVE".to_string();
+        }
+    };
+
+    stream.set_read_timeout(Some(Duration::from_secs(1)));
+
+    let bulk_message: RESPMessage = RESPMessage::BulkString("GETSERVERID".to_string());
+
+    let array = RESPMessage::Array(vec![
+        bulk_message
+    ]);
+
+    let serialized = array.serialize();
+    
+    match stream.write_all(&serialized) {
+        Ok(_) => {},
+        Err(e) => println!("Error: {}", e),
+        _ => println!("Default"),
+    }
+    let mut response = String::new();
+    match stream.read_to_string(&mut response) {
+        Ok(_) => println!("{}", response),
+        Err(e) => {},
+        _ => println!("Default case"),
+    }
+    response
+}
+
+// send message to notify a backup it shuld become the leader
+fn send_set_leader_message(port: String) -> String {
+    let addr = "localhost:".to_string() + "" + &port;
+    let mut stream = TcpStream::connect(addr).unwrap();
+
+    stream.set_read_timeout(Some(Duration::from_secs(1)));
+
+    let bulk_message: RESPMessage = RESPMessage::BulkString("SETLEADER".to_string());
+
+    let array = RESPMessage::Array(vec![
+        bulk_message
+    ]);
+
+    let serialized = array.serialize();
+    
+    match stream.write_all(&serialized) {
+        Ok(_) => println!("Write to stream OK"),
+        Err(e) => println!("Error: {}", e),
+        _ => println!("Default"),
+    }
+    let mut response = String::new();
+    match stream.read_to_string(&mut response) {
+        Ok(_) => println!("{}", response),
+        Err(e) => {},
+        _ => println!("Default case"),
+    }
+    response  
+}
+
+// send ping message to leader (leader always on port 6379)
+fn send_ping_message_to_leader() -> String {
+    let mut stream = match TcpStream::connect("localhost:6379") {
+        Ok(stream) => stream,
+        Err(e) => {
+            return e.to_string();
+        }
+    };
+
+    stream.set_read_timeout(Some(Duration::from_secs(1)));
+
+    let bulk_message: RESPMessage = RESPMessage::BulkString("PING".to_string());
+
+    let array = RESPMessage::Array(vec![
+        bulk_message
+    ]);
+
+    let serialized = array.serialize();
+    
+    match stream.write_all(&serialized) {
+        Ok(_) => println!("Write to stream OK"),
+        Err(e) => println!("Error: {}", e),
+        _ => println!("Default"),
+    }
+    let mut response = String::new();
+    match stream.read_to_string(&mut response) {
+        Ok(_) => println!("{}", response),
+        Err(e) => {},
+        _ => println!("Default case"),
+    }
+    response 
+}


### PR DESCRIPTION
Added simpleElection.rs to handle pinging the leader and starting an election when no PONG response is received from the leader within 10 seconds. 

When the leader (server on port 6379) fails, the first backup to notice will start an election and request the PIDs from each backup. This initiating server will then decide which backup has the highest PID and send this server a SETLEADER message causing that back up to become the leader. If the initiating server has the highest PID, it will elect itself as the leader. 

A list of all possible Ports is passed to the ping leader function and the initiating server will try to get the PID from each server. If a server is not up on a particular port, then it is not accounted for in the election.